### PR TITLE
perf(huya): optimize huya numeric live url extraction speed

### DIFF
--- a/platforms/src/main/kotlin/github/hua0512/plugins/huya/download/HuyaExtractorV2.kt
+++ b/platforms/src/main/kotlin/github/hua0512/plugins/huya/download/HuyaExtractorV2.kt
@@ -1,0 +1,151 @@
+/*
+ * MIT License
+ *
+ * Stream-rec  https://github.com/hua0512/stream-rec
+ *
+ * Copyright (c) 2024 hua0512 (https://github.com/hua0512)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package github.hua0512.plugins.huya.download
+
+import github.hua0512.data.media.MediaInfo
+import io.ktor.client.*
+import io.ktor.client.request.*
+import io.ktor.client.statement.*
+import io.ktor.http.*
+import kotlinx.serialization.json.*
+
+/**
+ * Huya extractor v2
+ *
+ * @note Only supports numeric room ids
+ * @author hua0512
+ * @date : 2024/5/21 20:20
+ */
+class HuyaExtractorV2(override val http: HttpClient, override val json: Json, override val url: String) : HuyaExtractor(http, json, url) {
+
+  companion object {
+    private const val MP_BASE_URL = "https://mp.huya.com/cache.php"
+  }
+
+  override val regexPattern = URL_REGEX.toRegex()
+
+  private lateinit var dataJson: JsonObject
+
+
+  init {
+    requestHeaders.forEach {
+      platformHeaders[it.first] = it.second
+    }
+  }
+
+  override fun match(): Boolean {
+    val result = super.match()
+
+    // check if the room id is numeric
+    if (!roomId.matches(Regex("\\d+"))) {
+      throw IllegalArgumentException("This extractor only supports numeric room ids")
+    }
+
+    return result
+  }
+
+  override suspend fun isLive(): Boolean {
+    val response = getResponse(MP_BASE_URL) {
+      contentType(ContentType.Application.Json)
+      parameter("do", "profileRoom")
+      parameter("m", "Live")
+      parameter("roomid", roomId)
+    }
+
+    if (response.status != HttpStatusCode.OK) throw IllegalStateException("Invalid response status ${response.status.value} from $url")
+
+    dataJson = json.parseToJsonElement(response.bodyAsText()).jsonObject
+
+    val status = dataJson["status"]?.jsonPrimitive?.int
+    val message = dataJson["message"]?.jsonPrimitive?.content
+    if (status != 200) {
+      throw IllegalStateException("Invalid status code $status from $url, message: $message")
+    }
+    val data = dataJson["data"]?.jsonObject ?: throw IllegalStateException("data is null from $url")
+    val realRoomStatus = data["realLiveStatus"]?.jsonPrimitive?.content ?: "OFF"
+    val liveStatus = data["liveStatus"]?.jsonPrimitive?.content ?: "OFF"
+
+    return realRoomStatus == "ON" && liveStatus == "ON"
+  }
+
+  override suspend fun extract(): MediaInfo {
+    val isLive = isLive()
+
+    val data = dataJson["data"]?.jsonObject ?: throw IllegalStateException("data is null from $url")
+    val profileInfo = data.jsonObject["profileInfo"]?.jsonObject
+
+    // get danmu properties
+    ayyuid = profileInfo?.get("yyid")?.jsonPrimitive?.long ?: 0
+    topsid = data["chTopId"]?.jsonPrimitive?.long ?: 0
+    subid = data["subChId"]?.jsonPrimitive?.long ?: 0
+    // get avatar
+    val avatarUrl = profileInfo?.get("avatar180")?.jsonPrimitive?.content ?: ""
+    // get streamer name
+    val streamerName = profileInfo?.get("nick")?.jsonPrimitive?.content ?: ""
+    val livedata = data["liveData"]?.jsonObject
+    // get stream title and cover
+    val streamTitle = livedata?.get("introduction")?.jsonPrimitive?.content ?: ""
+    val coverUrl = livedata?.get("screenshot")?.jsonPrimitive?.content ?: ""
+
+    val mediaInfo = MediaInfo(
+      site = BASE_URL,
+      title = streamTitle,
+      artist = streamerName,
+      coverUrl = coverUrl,
+      artistImageUrl = avatarUrl,
+      live = isLive,
+    )
+    // if not live, return basic media info
+    if (!isLive) return mediaInfo
+
+    // get stream info
+    val streamJson = data["stream"]?.jsonObject ?: throw IllegalStateException("stream is null from $url")
+    val baseStreamInfoList = streamJson["baseSteamInfoList"]?.jsonArray ?: throw IllegalStateException("baseStreamInfoList is null from $url")
+    if (baseStreamInfoList.isEmpty()) {
+      throw IllegalStateException("baseStreamInfoList is empty from $url")
+    }
+
+    // get bitrate list
+    val bitrateInfo = livedata?.get("bitRateInfo")?.jsonPrimitive?.content?.run {
+      json.parseToJsonElement(this).jsonArray
+    } ?: throw IllegalStateException("bitRateInfo is null from $url")
+
+    val maxBitRate = livedata["bitRate"]?.jsonPrimitive?.int ?: 0
+
+    // available bitrate list
+    val bitrateList: List<Pair<Int, String>> = bitrateInfo.mapIndexed { index, jsonElement ->
+      val bitrate = if (index == 0) maxBitRate else jsonElement.jsonObject["iBitRate"]?.jsonPrimitive?.int ?: 0
+      val displayName = jsonElement.jsonObject["sDisplayName"]?.jsonPrimitive?.content ?: ""
+      bitrate to displayName
+    }
+
+    // build stream info
+    val streams = extractLiveStreams(baseStreamInfoList, bitrateList, maxBitRate)
+    return mediaInfo.copy(streams = streams)
+  }
+
+}

--- a/platforms/src/test/kotlin/HuyaTest.kt
+++ b/platforms/src/test/kotlin/HuyaTest.kt
@@ -6,9 +6,7 @@ import github.hua0512.data.stream.Streamer
 import github.hua0512.plugins.huya.danmu.HuyaDanmu
 import github.hua0512.plugins.huya.download.Huya
 import github.hua0512.plugins.huya.download.HuyaExtractor
-import io.ktor.client.request.*
-import io.ktor.client.statement.*
-import io.ktor.http.*
+import github.hua0512.plugins.huya.download.HuyaExtractorV2
 import junit.framework.TestCase.assertEquals
 import junit.framework.TestCase.assertNotNull
 import kotlinx.coroutines.test.runTest
@@ -74,23 +72,23 @@ class HuyaTest {
   @Test
   fun testLive() = runTest {
     val client = app.client
-    val extractor = HuyaExtractor(client, app.json, streamingUrl)
-    assertNotNull(extractor.extract())
+    val extractor = HuyaExtractor(client, app.json, streamingUrl).apply {
+      prepare()
+    }
+    val mediaInfo = extractor.extract()
+    assertNotNull(mediaInfo)
+    println(mediaInfo)
   }
-
 
   @Test
   fun testLive2() = runTest {
-    val apiUrl = "https://mp.huya.com/cache.php"
-    val response = app.client.get(apiUrl) {
-      header(HttpHeaders.Origin, "https://www.huya.com")
-      header(HttpHeaders.Referrer, "https://www.huya.com")
-      parameter("m", "Live")
-      parameter("do", "profileRoom")
-      parameter("roomid", "660000")
+    val client = app.client
+    val extractor = HuyaExtractorV2(client, app.json, streamingUrl).apply {
+      prepare()
     }
-    val body = response.bodyAsText()
-    println(body)
+    val mediaInfo = extractor.extract()
+    assertNotNull(mediaInfo)
+    println(mediaInfo)
   }
 
   @Test

--- a/stream-rec/src/main/kotlin/github/hua0512/services/PlatformDownloaderFactory.kt
+++ b/stream-rec/src/main/kotlin/github/hua0512/services/PlatformDownloaderFactory.kt
@@ -37,6 +37,7 @@ import github.hua0512.plugins.douyu.download.DouyuExtractor
 import github.hua0512.plugins.huya.danmu.HuyaDanmu
 import github.hua0512.plugins.huya.download.Huya
 import github.hua0512.plugins.huya.download.HuyaExtractor
+import github.hua0512.plugins.huya.download.HuyaExtractorV2
 import github.hua0512.plugins.pandalive.danmu.PandaliveDanmu
 import github.hua0512.plugins.pandalive.download.Pandalive
 import github.hua0512.plugins.pandalive.download.PandaliveExtractor
@@ -53,7 +54,16 @@ import github.hua0512.plugins.twitch.download.TwitchExtractor
 object PlatformDownloaderFactory {
 
   fun createDownloader(app: App, platform: StreamingPlatform, url: String) = when (platform) {
-    StreamingPlatform.HUYA -> Huya(app, HuyaDanmu(app), HuyaExtractor(app.client, app.json, url))
+    StreamingPlatform.HUYA -> {
+      val isNumericUrl = url.split("/").last().matches(Regex("\\d+"))
+      // use v2 extractor for numeric urls
+      if (isNumericUrl) {
+        Huya(app, HuyaDanmu(app), HuyaExtractorV2(app.client, app.json, url))
+      } else {
+        Huya(app, HuyaDanmu(app), HuyaExtractor(app.client, app.json, url))
+      }
+    }
+
     StreamingPlatform.DOUYIN -> Douyin(app, DouyinDanmu(app), DouyinExtractor(app.client, app.json, url))
     StreamingPlatform.DOUYU -> Douyu(app, DouyuDanmu(app), DouyuExtractor(app.client, app.json, url))
     StreamingPlatform.TWITCH -> Twitch(app, TwitchDanmu(app), TwitchExtractor(app.client, app.json, url))


### PR DESCRIPTION
- Introduce `HuyaExtractorV2` as a faster extraction method for numeric live URLs
- Make `HuyaExtractor` class `open` and change visibility of some properties to `protected`
- Update `HuyaTest` to use the new extractor
- Update `PlatformDownloaderFactory` to use `HuyaExtractorV2` when the URL is numeric
- Change the `ctype` value in `buildUrl` function for `HuyaExtractor`