### PR TITLE
build(Dockerfile): change to use `amazoncorretto:21-al2023-headless` as runtime image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,20 +3,33 @@ WORKDIR /app
 COPY . .
 RUN gradle stream-rec:build -x test --no-daemon
 
-FROM amazoncorretto:21-alpine3.19
+FROM amazoncorretto:21-al2023-headless
 WORKDIR /app
 COPY --from=builder /app/stream-rec/build/libs/stream-rec.jar app.jar
 
-# Add libc6-compat for Android room
-RUN apk add --no-cache libc6-compat ffmpeg sqlite rclone tzdata
+# Install dependencies
+RUN yum update -y && \
+    yum install -y unzip tar python3 python3-pip which xz tzdata && \
+    yum clean all && \
+    rm -rf /var/cache/yum
 
-# Install Streamlink
-#RUN apk add --no-cache streamlink --repository=https://dl-cdn.alpinelinux.org/alpine/edge/community
+# Install ffmpeg
+RUN curl -L https://johnvansickle.com/ffmpeg/releases/ffmpeg-release-i686-static.tar.xz | tar -xJ && \
+    mv ffmpeg-*-static/ffmpeg /usr/local/bin/ && \
+    mv ffmpeg-*-static/ffprobe /usr/local/bin/ && \
+    rm -rf ffmpeg-*-static
 
-# Temporal solution until #https://github.com/hua0512/stream-rec/issues/54 is fixed
-ENV PIPX_BIN_DIR=/usr/bin
-RUN apk add --no-cache python3 py3-pip pipx && \
-    pipx install streamlink
+# Install rclone
+RUN curl -O https://downloads.rclone.org/rclone-current-linux-amd64.zip && \
+    unzip rclone-current-linux-amd64.zip && \
+    cd rclone-*-linux-amd64 && \
+    cp rclone /usr/bin/ && \
+    chown root:root /usr/bin/rclone && \
+    chmod 755 /usr/bin/rclone && \
+    rm -rf /rclone-current-linux-amd64.zip /rclone-*-linux-amd64
+
+# Install streamlink
+RUN pip3 install streamlink
 
 # Set timezone
 ENV TZ ${TZ:-Europe/Paris}

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,8 @@ COPY --from=builder /app/stream-rec/build/libs/stream-rec.jar app.jar
 # Install dependencies
 RUN yum update -y && \
     yum install -y unzip tar python3 python3-pip which xz tzdata nscd && \
+    systemctl enable nscd && \
+    pip3 install streamlink && \
     yum clean all && \
     rm -rf /var/cache/yum
 
@@ -28,12 +30,9 @@ RUN curl -O https://downloads.rclone.org/rclone-current-linux-amd64.zip && \
     chmod 755 /usr/bin/rclone && \
     rm -rf /rclone-current-linux-amd64.zip /rclone-*-linux-amd64
 
-# Install streamlink
-RUN pip3 install streamlink
-
 # Set timezone
 ENV TZ=${TZ:-Europe/Paris}
 
 EXPOSE 12555
 
-CMD ["java", "-jar", "app.jar"]
+CMD nscd && java -jar app.jar

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ COPY --from=builder /app/stream-rec/build/libs/stream-rec.jar app.jar
 
 # Install dependencies
 RUN yum update -y && \
-    yum install -y unzip tar python3 python3-pip which xz tzdata nscd && \
+    yum install -y unzip tar python3 python3-pip which xz tzdata nscd findutils && \
     systemctl enable nscd && \
     pip3 install streamlink && \
     yum clean all && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,12 +9,12 @@ COPY --from=builder /app/stream-rec/build/libs/stream-rec.jar app.jar
 
 # Install dependencies
 RUN yum update -y && \
-    yum install -y unzip tar python3 python3-pip which xz tzdata && \
+    yum install -y unzip tar python3 python3-pip which xz tzdata nscd && \
     yum clean all && \
     rm -rf /var/cache/yum
 
 # Install ffmpeg
-RUN curl -L https://johnvansickle.com/ffmpeg/releases/ffmpeg-release-i686-static.tar.xz | tar -xJ && \
+RUN curl -L https://johnvansickle.com/ffmpeg/releases/ffmpeg-release-amd64-static.tar.xz | tar -xJ && \
     mv ffmpeg-*-static/ffmpeg /usr/local/bin/ && \
     mv ffmpeg-*-static/ffprobe /usr/local/bin/ && \
     rm -rf ffmpeg-*-static

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM gradle:8.8-jdk21-alpine as builder
+FROM gradle:8.8-jdk21-alpine AS builder
 WORKDIR /app
 COPY . .
 RUN gradle stream-rec:build -x test --no-daemon
@@ -32,7 +32,7 @@ RUN curl -O https://downloads.rclone.org/rclone-current-linux-amd64.zip && \
 RUN pip3 install streamlink
 
 # Set timezone
-ENV TZ ${TZ:-Europe/Paris}
+ENV TZ=${TZ:-Europe/Paris}
 
 EXPOSE 12555
 


### PR DESCRIPTION
- Change base image from `amazoncorretto:21-alpine3.19` to `amazoncorretto:21-al2023-headless`
- Replace `apk` commands with `yum` for package installation
- Install FFmpeg directly rather than via `apk` package manager
- Install `rclone` using curl and unzip instead of `apk`
- Install `streamlink` with `pip3` instead of `pipx`

Closes #54 and #93