### PR TITLE
chore(http): change to use OkHttp engine instead

### DIFF
--- a/base/build.gradle.kts
+++ b/base/build.gradle.kts
@@ -20,7 +20,7 @@ dependencies {
   implementation(libs.org.jetbrains.kotlinx.datetime)
   implementation(libs.me.tongfei.progressbar)
   implementation(libs.io.ktor.client.core)
-  implementation(libs.io.ktor.client.cio)
+  implementation(libs.io.ktor.client.okhttp)
   implementation(libs.io.ktor.client.encoding)
   implementation(libs.io.ktor.client.content.negotiation)
   implementation(libs.io.ktor.serialization.kotlinx.json)

--- a/base/src/main/kotlin/github/hua0512/app/App.kt
+++ b/base/src/main/kotlin/github/hua0512/app/App.kt
@@ -28,10 +28,11 @@ package github.hua0512.app
 
 import github.hua0512.data.config.AppConfig
 import github.hua0512.plugins.download.COMMON_USER_AGENT
+import github.hua0512.utils.RemoveWebSocketExtensionsInterceptor
 import github.hua0512.utils.isWindows
 import io.ktor.client.*
 import io.ktor.client.engine.*
-import io.ktor.client.engine.cio.*
+import io.ktor.client.engine.okhttp.OkHttp
 import io.ktor.client.plugins.*
 import io.ktor.client.plugins.compression.*
 import io.ktor.client.plugins.contentnegotiation.*
@@ -74,7 +75,7 @@ class App(val json: Json) {
   }
 
   val client by lazy {
-    HttpClient(CIO) {
+    HttpClient(OkHttp) {
       engine {
         pipelining = true
         // Configure proxy
@@ -85,6 +86,10 @@ class App(val json: Json) {
           val httpProxyUrl = Url(httpProxy)
           logger.info("Using HTTP proxy: {}", httpProxyUrl)
           proxy = ProxyBuilder.http(httpProxyUrl)
+        }
+        config {
+          // Workaround for: https://youtrack.jetbrains.com/issue/KTOR-6266/OkHttp-Remove-the-default-WebSocket-extension-header-Sec-WebSocket-Extensions
+          addInterceptor(RemoveWebSocketExtensionsInterceptor())
         }
       }
       install(Logging) {

--- a/base/src/main/kotlin/github/hua0512/plugins/danmu/base/Danmu.kt
+++ b/base/src/main/kotlin/github/hua0512/plugins/danmu/base/Danmu.kt
@@ -36,7 +36,6 @@ import github.hua0512.data.stream.Streamer
 import github.hua0512.plugins.danmu.exceptions.DownloadProcessFinishedException
 import github.hua0512.utils.withIORetry
 import io.ktor.client.plugins.websocket.*
-import io.ktor.client.plugins.websocket.cio.*
 import io.ktor.client.request.*
 import io.ktor.http.*
 import io.ktor.websocket.*
@@ -195,13 +194,13 @@ abstract class Danmu(val app: App, val enablePing: Boolean = false) {
       } else {
         val urlBuilder = URLBuilder(websocketUrl)
         if (urlBuilder.protocol.isSecure()) {
-          app.client.wssRaw(host = urlBuilder.host, port = urlBuilder.port, path = urlBuilder.encodedPath, request = {
+          app.client.wss(host = urlBuilder.host, port = urlBuilder.port, path = urlBuilder.encodedPath, request = {
             fillRequest()
           }) {
             processSession()
           }
         } else {
-          app.client.wsRaw(host = urlBuilder.host, port = urlBuilder.port, path = urlBuilder.encodedPath, request = {
+          app.client.ws(host = urlBuilder.host, port = urlBuilder.port, path = urlBuilder.encodedPath, request = {
             fillRequest()
           }) {
             processSession()

--- a/base/src/main/kotlin/github/hua0512/utils/Okhttp.kt
+++ b/base/src/main/kotlin/github/hua0512/utils/Okhttp.kt
@@ -1,0 +1,45 @@
+/*
+ * MIT License
+ *
+ * Stream-rec  https://github.com/hua0512/stream-rec
+ *
+ * Copyright (c) 2024 hua0512 (https://github.com/hua0512)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package github.hua0512.utils
+
+import okhttp3.Interceptor
+import okhttp3.Response
+
+/**
+ * OkHttp interceptor to remove `Sec-WebSocket-Extensions` header
+ * @author hua0512
+ * @date : 2024/7/8 13:37
+ */
+class RemoveWebSocketExtensionsInterceptor : Interceptor {
+  override fun intercept(chain: Interceptor.Chain): Response {
+    val originalRequest = chain.request()
+    val modifiedRequest = originalRequest.newBuilder()
+      .removeHeader("Sec-WebSocket-Extensions")
+      .build()
+    return chain.proceed(modifiedRequest)
+  }
+}


### PR DESCRIPTION
- Added `RemoveWebSocketExtensionsInterceptor` in `Okhttp.kt` to remove `Sec-WebSocket-Extensions` header
- Utilized the interceptor in `App.kt`, updated HttpClient engine from `CIO` to `OkHttp` and added the interceptor
- This interceptor will be used in the HttpClient configuration

Fixes #95 