### PR TITLE
feat(backend): implement batch delete for stream and upload data

### DIFF
--- a/base/src/main/kotlin/github/hua0512/repo/stream/StreamDataRepo.kt
+++ b/base/src/main/kotlin/github/hua0512/repo/stream/StreamDataRepo.kt
@@ -60,5 +60,7 @@ interface StreamDataRepo {
 
 
   suspend fun save(streamData: StreamData): StreamData
+
   suspend fun delete(id: StreamDataId): Boolean
+  suspend fun delete(ids: List<StreamDataId>): Boolean
 }

--- a/base/src/main/kotlin/github/hua0512/repo/upload/UploadRepo.kt
+++ b/base/src/main/kotlin/github/hua0512/repo/upload/UploadRepo.kt
@@ -55,6 +55,7 @@ interface UploadRepo {
   suspend fun getUploadData(uploadDataId: UploadDataId): UploadData?
   suspend fun updateUploadData(uploadData: UploadData): Boolean
   suspend fun deleteUploadData(uploadData: UploadData)
+  suspend fun deleteUploadData(ids: List<UploadDataId>)
   suspend fun getUploadDataResults(uploadDataId: UploadDataId): List<UploadResult>
   suspend fun getAllUploadResults(): List<UploadResult>
   suspend fun deleteUploadResult(result: UploadResult): Boolean

--- a/stream-rec-backend/src/main/kotlin/github/hua0512/backend/routes/StreamData.kt
+++ b/stream-rec-backend/src/main/kotlin/github/hua0512/backend/routes/StreamData.kt
@@ -95,9 +95,27 @@ fun Route.streamsRoute(json: Json, streamsRepo: StreamDataRepo) {
       try {
         streamsRepo.delete(StreamDataId(id))
       } catch (e: Exception) {
+        e.printStackTrace()
         call.respond(HttpStatusCode.InternalServerError, "Failed to delete stream data")
         return@delete
       }
+      call.respond(HttpStatusCode.OK, "Stream data deleted")
+    }
+
+    delete("/batch") {
+      val ids = call.request.queryParameters["ids"]?.split(",")?.mapNotNull { it.toLongOrNull() }
+      if (ids.isNullOrEmpty()) {
+        call.respond(HttpStatusCode.BadRequest, "Invalid ids")
+        return@delete
+      }
+      try {
+        streamsRepo.delete(ids.map { StreamDataId(it) })
+      } catch (e: Exception) {
+        e.printStackTrace()
+        call.respond(HttpStatusCode.InternalServerError, "Failed to delete stream data")
+        return@delete
+      }
+
       call.respond(HttpStatusCode.OK, "Stream data deleted")
     }
   }

--- a/stream-rec-backend/src/main/kotlin/github/hua0512/backend/routes/Uploads.kt
+++ b/stream-rec-backend/src/main/kotlin/github/hua0512/backend/routes/Uploads.kt
@@ -180,5 +180,21 @@ fun Route.uploadRoute(json: Json, repo: UploadRepo) {
       }
       call.respond(HttpStatusCode.OK)
     }
+
+    delete("/batch") {
+      val ids = call.request.queryParameters["ids"]?.split(",")?.mapNotNull { it.toLongOrNull() }
+      if (ids.isNullOrEmpty()) {
+        call.respond(HttpStatusCode.BadRequest, "Invalid ids")
+        return@delete
+      }
+      try {
+        repo.deleteUploadData(ids.map { UploadDataId(it) })
+      } catch (e: Exception) {
+        logger.error("Failed to delete upload data : ${e.message}")
+        call.respond(HttpStatusCode.InternalServerError, "Failed to delete upload data : ${e.message}")
+        return@delete
+      }
+      call.respond(HttpStatusCode.OK)
+    }
   }
 }

--- a/stream-rec/src/main/kotlin/github/hua0512/repo/StreamDataRepository.kt
+++ b/stream-rec/src/main/kotlin/github/hua0512/repo/StreamDataRepository.kt
@@ -132,4 +132,11 @@ class StreamDataRepository(val dao: StreamDataDao, private val statsDao: StatsDa
     val streamData = StreamDataEntity(id = id.value, "", outputFilePath = "")
     dao.delete(streamData) == 1
   }
+
+  override suspend fun delete(ids: List<StreamDataId>): Boolean {
+    return withIOContext {
+      val streamData = ids.map { StreamDataEntity(id = it.value, "", outputFilePath = "") }
+      dao.delete(streamData) == ids.size
+    }
+  }
 }

--- a/stream-rec/src/main/kotlin/github/hua0512/repo/UploadActionRepository.kt
+++ b/stream-rec/src/main/kotlin/github/hua0512/repo/UploadActionRepository.kt
@@ -37,6 +37,7 @@ import github.hua0512.data.UploadDataId
 import github.hua0512.data.stats.StatsEntity
 import github.hua0512.data.stream.StreamData
 import github.hua0512.data.upload.*
+import github.hua0512.data.upload.entity.UploadDataEntity
 import github.hua0512.repo.stream.StreamDataRepo
 import github.hua0512.repo.stream.StreamerRepo
 import github.hua0512.repo.upload.UploadRepo
@@ -296,6 +297,12 @@ class UploadActionRepository(
         throw IllegalArgumentException("Upload data ID is required for deletion.")
       }
       uploadDataDao.delete(uploadData.toEntity())
+    }
+  }
+
+  override suspend fun deleteUploadData(ids: List<UploadDataId>) {
+    return withIOContext {
+      uploadDataDao.delete(ids.map { UploadDataEntity(it.value, "", UploadState.NOT_STARTED, 0, 0) })
     }
   }
 


### PR DESCRIPTION
- Add `delete` method for batch deletion in `StreamDataRepository`
- Add `deleteUploadData` method for batch deletion in `UploadActionRepository`
- Update `StreamDataRepo` and `UploadRepo` interfaces for batch deletion
- Implement batch delete API endpoints in `Uploads.kt` and `StreamData.kt` files