### PR TITLE
refactor(huya-danmu): use reversed-engineered danmu registration workflow

### DIFF
--- a/platforms/src/main/kotlin/github/hua0512/plugins/huya/danmu/HuyaDanmu.kt
+++ b/platforms/src/main/kotlin/github/hua0512/plugins/huya/danmu/HuyaDanmu.kt
@@ -27,7 +27,6 @@
 package github.hua0512.plugins.huya.danmu
 
 import com.qq.tars.protocol.tars.TarsInputStream
-import com.qq.tars.protocol.tars.TarsOutputStream
 import github.hua0512.app.App
 import github.hua0512.data.media.DanmuDataWrapper
 import github.hua0512.data.media.DanmuDataWrapper.DanmuData
@@ -36,9 +35,14 @@ import github.hua0512.plugins.danmu.base.Danmu
 import github.hua0512.plugins.huya.danmu.msg.HuyaMessageNotice
 import github.hua0512.plugins.huya.danmu.msg.HuyaPushMessage
 import github.hua0512.plugins.huya.danmu.msg.HuyaSocketCommand
-import github.hua0512.plugins.huya.danmu.msg.HuyaUserInfo
 import github.hua0512.plugins.huya.danmu.msg.data.HuyaCmds
 import github.hua0512.plugins.huya.danmu.msg.data.HuyaOperations
+import github.hua0512.plugins.huya.danmu.msg.data.HuyaSourceType
+import github.hua0512.plugins.huya.danmu.msg.req.HuyaGetLivingInfoReq
+import github.hua0512.plugins.huya.danmu.msg.req.HuyaLiveLaunchReq
+import github.hua0512.plugins.huya.danmu.msg.req.HuyaUserInfo
+import github.hua0512.plugins.huya.danmu.msg.req.HuyaWSRegisterGroupReq
+import github.hua0512.plugins.huya.danmu.msg.req.HuyaWup
 import io.ktor.websocket.*
 import kotlinx.datetime.Clock
 import kotlinx.datetime.Instant
@@ -53,50 +57,77 @@ import kotlin.time.toDuration
  */
 class HuyaDanmu(app: App) : Danmu(app, enablePing = false) {
 
-  override var websocketUrl: String = "wss://cdnws.api.huya.com:443"
+  override var websocketUrl: String = HUYA_WS_URL
   override val heartBeatDelay: Long = 60.toDuration(DurationUnit.SECONDS).inWholeMilliseconds
 
   // @formatter:off
   override val heartBeatPack: ByteArray = byteArrayOf(0x00, 0x03, 0x1d, 0x00, 0x00, 0x69, 0x00, 0x00, 0x00, 0x69, 0x10, 0x03, 0x2c, 0x3c, 0x4c, 0x56, 0x08, 0x6f, 0x6e, 0x6c, 0x69, 0x6e, 0x65, 0x75, 0x69, 0x66, 0x0f, 0x4f, 0x6e, 0x55, 0x73, 0x65, 0x72, 0x48, 0x65, 0x61, 0x72, 0x74, 0x42, 0x65, 0x61, 0x74, 0x7d, 0x00, 0x00, 0x3c, 0x08, 0x00, 0x01, 0x06, 0x04, 0x74, 0x52, 0x65, 0x71, 0x1d, 0x00, 0x00, 0x2f, 0x0a, 0x0a, 0x0c, 0x16, 0x00, 0x26, 0x00, 0x36, 0x07, 0x61, 0x64, 0x72, 0x5f, 0x77, 0x61, 0x70, 0x46, 0x00, 0x0b, 0x12, 0x03, 0xae.toByte(), 0xf0.toByte(), 0x0f, 0x22, 0x03, 0xae.toByte(), 0xf0.toByte(), 0x0f, 0x3c, 0x42, 0x6d, 0x52, 0x02, 0x60, 0x5c, 0x60, 0x01, 0x7c, 0x82.toByte(), 0x00, 0x0b, 0xb0.toByte(), 0x1f, 0x9c.toByte(), 0xac.toByte(), 0x0b, 0x8c.toByte(), 0x98.toByte(), 0x0c, 0xa8.toByte(), 0x0c)
   // @formatter:on
 
-  internal var ayyuid: Long = 0
-  internal var topsid: Long = 0
-  internal var subid: Long = 0
+  internal var presenterUid = 0L
+
+
+  private companion object {
+    private const val VERSION = 2408161057
+    private const val HUYA_WS_URL = "wss://cdnws.api.huya.com:443"
+  }
 
 
   override suspend fun initDanmu(streamer: Streamer, startTime: Instant): Boolean {
     // check if streamer url is empty
     if (streamer.url.isEmpty()) return false
 
-    logger.info("(${streamer.name}) Huya room info: ayyuid=$ayyuid, topsid=$topsid, subid=$subid")
-    if (ayyuid == 0L || topsid == 0L || subid == 0L) {
-      logger.error("Failed to get huya room info: ayyuid=$ayyuid, topsid=$topsid, subid=$subid")
+    logger.info("(${streamer.name}) Huya room info: presenterUid=${presenterUid}")
+    if (presenterUid == 0L) {
+      logger.error("Failed to get huya room info: presenterUid is 0")
       return false
     }
     return true
   }
 
-  override fun oneHello(): ByteArray {
-    val userInfo = HuyaUserInfo(
-      ayyuid,
-      lTid = topsid,
-      lSid = subid,
-    )
-    // create a TarsOutputStream and write userInfo to it
-    val tarsOutputStream = TarsOutputStream().also {
-      userInfo.writeTo(it)
-    }
+  override fun oneHello(): ByteArray = ByteArray(0)
 
-    return HuyaSocketCommand(
-      iCmdType = HuyaOperations.EWSCmd_RegisterReq.code,
-      vData = tarsOutputStream.toByteArray()
-    ).run {
-      TarsOutputStream().run {
-        writeTo(this)
-        toByteArray()
-      }
+  override suspend fun sendHello(session: WebSocketSession) {
+    // lUid, sCookie, sGuid are not required
+    // omitting them
+    val userInfo = HuyaUserInfo(
+      sUA = "webh5&$VERSION&websocket",
+      sDeviceInfo = "chrome",
+    )
+
+    // create a HuyaGetLivingInfoReq wup
+    val command = HuyaSocketCommand(
+      iCmdType = HuyaOperations.EWSCmd_WupReq.code,
+      vData = HuyaWup().also {
+        it.tarsServantRequest.servantName = "huyaliveui"
+        it.tarsServantRequest.functionName = "getLivingInfo"
+        it.uniAttribute.put(
+          "tReq", HuyaGetLivingInfoReq(
+            userInfo,
+            lPresenterUid = presenterUid
+          )
+        )
+      }.encode()
+    )
+    session.send(command.toByteArray())
+
+    // create a HuyaLiveLaunchReq wup
+    val liveLaunchReq = HuyaWup().also {
+      it.tarsServantRequest.servantName = "liveui"
+      it.tarsServantRequest.functionName = "doLaunch"
+      it.uniAttribute.put("tReq", HuyaLiveLaunchReq(
+        tId = userInfo,
+        bSupportDomain = true
+      ).also {
+        it.tLiveUB.eSource = HuyaSourceType.PC_WEB.value
+      })
     }
+    session.send(
+      HuyaSocketCommand(
+        iCmdType = HuyaOperations.EWSCmd_WupReq.code,
+        vData = liveLaunchReq.encode()
+      ).toByteArray()
+    )
   }
 
   override suspend fun decodeDanmu(session: WebSocketSession, data: ByteArray): List<DanmuDataWrapper?> {
@@ -104,6 +135,32 @@ class HuyaDanmu(app: App) : Danmu(app, enablePing = false) {
       readFrom(TarsInputStream(data))
     }
     when (val commandType = huyaSocketCommand.iCmdType) {
+      HuyaOperations.EWSCmd_WupRsp.code -> {
+        val wup = try {
+          HuyaWup().apply {
+            readFrom(TarsInputStream(huyaSocketCommand.vData).also {
+              it.setServerEncoding(StandardCharsets.UTF_8.name())
+            })
+          }
+        } catch (e: Exception) {
+          // ignore invalid wup
+          return emptyList()
+        }
+
+        logger.trace("Received wup response: ${wup.tarsServantRequest.functionName}")
+
+        if (wup.tarsServantRequest.functionName == "doLaunch") {
+          val huyaRegisterGroupReq = HuyaSocketCommand(
+            iCmdType = HuyaOperations.EWSCmdC2S_RegisterGroupReq.code,
+            vData = HuyaWSRegisterGroupReq().also {
+              it.vGroupId = listOf("live:$presenterUid", "chat:$presenterUid")
+            }.toByteArray()
+          )
+          session.send(huyaRegisterGroupReq.toByteArray())
+          logger.trace("Sent register group request for presenterUid=$presenterUid")
+        }
+      }
+
       HuyaOperations.EWSCmdS2C_MsgPushReq.code -> {
         val msg = TarsInputStream(huyaSocketCommand.vData).run {
           HuyaPushMessage().apply {

--- a/platforms/src/main/kotlin/github/hua0512/plugins/huya/danmu/msg/HuyaLiveAppUAEx.kt
+++ b/platforms/src/main/kotlin/github/hua0512/plugins/huya/danmu/msg/HuyaLiveAppUAEx.kt
@@ -23,60 +23,33 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-
 package github.hua0512.plugins.huya.danmu.msg
 
 import com.qq.tars.protocol.tars.TarsInputStream
 import com.qq.tars.protocol.tars.TarsOutputStream
 import com.qq.tars.protocol.tars.TarsStructBase
 
-/**
- * Huya websocket user info
- * @author hua0512
- * @date : 2024/2/10 18:26
- */
-data class HuyaUserInfo(
-  var lUid: Long = 0,
-  var bAnonymous: Boolean = true,
-  var sGuid: String = "",
-  var sToken: String = "",
-  var lTid: Long = 0,
-  var lSid: Long = 0,
-  var lGroupId: Long = 0,
-  var lGroupType: Long = 0,
-  var sAppId: String = "",
-  var sUA: String = "",
+data class HuyaLiveAppUAEx(
+  var sIMEI: String? = "",
+  var sAPN: String? = "",
+  var sNetType: String? = "",
+  var sDeviceId: String? = "",
+  var sMId: String? = "",
 ) : TarsStructBase() {
+
   override fun writeTo(os: TarsOutputStream) {
-    with(os) {
-      write(lUid, 0)
-      write(bAnonymous, 1)
-      write(sGuid, 2)
-      write(sToken, 3)
-      write(lTid, 4)
-      write(lSid, 5)
-      write(lGroupId, 6)
-      write(lGroupType, 7)
-      write(sAppId, 8)
-      write(sUA, 9)
-    }
+    os.write(this.sIMEI, 1)
+    os.write(this.sAPN, 2)
+    os.write(this.sNetType, 3)
+    os.write(this.sDeviceId, 4)
+    os.write(this.sMId, 5)
   }
 
-  override fun readFrom(ins: TarsInputStream) {
-    ins.apply {
-      lUid = read(lUid, 0, false)
-      bAnonymous = read(bAnonymous, 1, false)
-      sGuid = read(sGuid, 2, false)
-      sToken = read(sToken, 3, false)
-      lTid = read(lTid, 4, false)
-      lSid = read(lSid, 5, false)
-      lGroupId = read(lGroupId, 6, false)
-      lGroupType = read(lGroupType, 7, false)
-      sAppId = read(sAppId, 8, false)
-      sUA = read(sUA, 9, false)
-    }
+  override fun readFrom(`is`: TarsInputStream) {
+    this.sIMEI = `is`.read(this.sIMEI, 1, false)
+    this.sAPN = `is`.read(this.sAPN, 2, false)
+    this.sNetType = `is`.read(this.sNetType, 3, false)
+    this.sDeviceId = `is`.read(this.sDeviceId, 4, false)
+    this.sMId = `is`.read(this.sMId, 5, false)
   }
-
-  override fun newInit(): TarsStructBase = this.copy()
-
 }

--- a/platforms/src/main/kotlin/github/hua0512/plugins/huya/danmu/msg/HuyaLiveUserbase.kt
+++ b/platforms/src/main/kotlin/github/hua0512/plugins/huya/danmu/msg/HuyaLiveUserbase.kt
@@ -1,0 +1,49 @@
+/*
+ * MIT License
+ *
+ * Stream-rec  https://github.com/hua0512/stream-rec
+ *
+ * Copyright (c) 2024 hua0512 (https://github.com/hua0512)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package github.hua0512.plugins.huya.danmu.msg
+
+import com.qq.tars.protocol.tars.TarsInputStream
+import com.qq.tars.protocol.tars.TarsOutputStream
+import com.qq.tars.protocol.tars.TarsStructBase
+
+data class HuyaLiveUserbase(
+  var eSource: Int = 0,
+  var eType: Int = 0,
+  var tUAEx: HuyaLiveAppUAEx? = HuyaLiveAppUAEx(),
+) : TarsStructBase() {
+
+  override fun writeTo(os: TarsOutputStream) {
+    os.write(this.eSource, 0)
+    os.write(this.eType, 1)
+    os.write(this.tUAEx, 2)
+  }
+
+  override fun readFrom(`is`: TarsInputStream) {
+    this.eSource = `is`.read(this.eSource, 0, false)
+    this.eType = `is`.read(this.eType, 1, false)
+    this.tUAEx = `is`.directRead(this.tUAEx, 2, false) as HuyaLiveAppUAEx?
+  }
+}

--- a/platforms/src/main/kotlin/github/hua0512/plugins/huya/danmu/msg/data/HuyaSourceType.kt
+++ b/platforms/src/main/kotlin/github/hua0512/plugins/huya/danmu/msg/data/HuyaSourceType.kt
@@ -1,0 +1,36 @@
+/*
+ * MIT License
+ *
+ * Stream-rec  https://github.com/hua0512/stream-rec
+ *
+ * Copyright (c) 2024 hua0512 (https://github.com/hua0512)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package github.hua0512.plugins.huya.danmu.msg.data
+
+/**
+ * Huya source types
+ * @author hua0512
+ * @date : 2024/8/18 0:21
+ */
+enum class HuyaSourceType(val value: Int) {
+  PC_WEB(3)
+}

--- a/platforms/src/main/kotlin/github/hua0512/plugins/huya/danmu/msg/req/HuyaGetLivingInfoReq.kt
+++ b/platforms/src/main/kotlin/github/hua0512/plugins/huya/danmu/msg/req/HuyaGetLivingInfoReq.kt
@@ -1,0 +1,80 @@
+/*
+ * MIT License
+ *
+ * Stream-rec  https://github.com/hua0512/stream-rec
+ *
+ * Copyright (c) 2024 hua0512 (https://github.com/hua0512)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package github.hua0512.plugins.huya.danmu.msg.req
+
+import com.qq.tars.protocol.tars.TarsInputStream
+import com.qq.tars.protocol.tars.TarsOutputStream
+import com.qq.tars.protocol.tars.TarsStructBase
+
+/**
+ * Huya danmu get living info request
+ * Extracted from https://hd2.huya.com/fedbasic/huyabaselibs/taf-signal/taf-signal.global.0.0.12.prod.js
+ * @author hua0512
+ * @date : 2024/8/17 14:25
+ */
+data class HuyaGetLivingInfoReq(
+  var tId: HuyaUserInfo,
+  var lTopSid: Long = 0,
+  var lSubSid: Long = 0,
+  var lPresenterUid: Long = 0,
+  var sTraceSource: String = "",
+  var sPassword: String = "",
+  var iRoomId: Int = 0,
+  var iFreeFollowFlag: Int = 0,
+  var iIpStack: Int = 0,
+) : TarsStructBase() {
+
+  override fun writeTo(out: TarsOutputStream) {
+    with(out) {
+      write(tId, 0)
+      write(lTopSid, 1)
+      write(lSubSid, 2)
+      write(lPresenterUid, 3)
+      write(sTraceSource, 4)
+      write(sPassword, 5)
+      write(iRoomId, 6)
+      write(iFreeFollowFlag, 7)
+      write(iIpStack, 8)
+    }
+  }
+
+  override fun readFrom(ins: TarsInputStream) {
+    with(ins) {
+      tId = directRead(tId, 0, false) as HuyaUserInfo
+      lTopSid = read(lTopSid, 1, false)
+      lSubSid = read(lSubSid, 2, false)
+      lPresenterUid = read(lPresenterUid, 3, false)
+      sTraceSource = read(sTraceSource, 4, false)
+      sPassword = read(sPassword, 5, false)
+      iRoomId = read(iRoomId, 6, false)
+      iFreeFollowFlag = read(iFreeFollowFlag, 7, false)
+      iIpStack = read(iIpStack, 8, false)
+    }
+  }
+
+  override fun newInit(): TarsStructBase = this.copy()
+}

--- a/platforms/src/main/kotlin/github/hua0512/plugins/huya/danmu/msg/req/HuyaLiveLaunchReq.kt
+++ b/platforms/src/main/kotlin/github/hua0512/plugins/huya/danmu/msg/req/HuyaLiveLaunchReq.kt
@@ -1,0 +1,56 @@
+/*
+ * MIT License
+ *
+ * Stream-rec  https://github.com/hua0512/stream-rec
+ *
+ * Copyright (c) 2024 hua0512 (https://github.com/hua0512)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package github.hua0512.plugins.huya.danmu.msg.req
+
+import com.qq.tars.protocol.tars.TarsInputStream
+import com.qq.tars.protocol.tars.TarsOutputStream
+import com.qq.tars.protocol.tars.TarsStructBase
+import github.hua0512.plugins.huya.danmu.msg.HuyaLiveUserbase
+
+/**
+ * Huya danmu live launch info request
+ * Extracted from https://hd2.huya.com/fedbasic/huyabaselibs/taf-signal/taf-signal.global.0.0.12.prod.js
+ * @author hua0512
+ * @date : 2024/8/17 14:25
+ */
+data class HuyaLiveLaunchReq(
+  var tId: HuyaUserInfo = HuyaUserInfo(),
+  var tLiveUB: HuyaLiveUserbase = HuyaLiveUserbase(),
+  var bSupportDomain: Boolean = false,
+) : TarsStructBase() {
+
+  override fun writeTo(os: TarsOutputStream) {
+    os.write(this.tId, 0)
+    os.write(this.tLiveUB, 1)
+    os.write(this.bSupportDomain, 2)
+  }
+
+  override fun readFrom(`is`: TarsInputStream) {
+    this.tId = `is`.directRead(this.tId, 0, false) as HuyaUserInfo
+    this.tLiveUB = `is`.directRead(this.tLiveUB, 1, false) as HuyaLiveUserbase
+    this.bSupportDomain = `is`.read(this.bSupportDomain, 2, false)
+  }
+}

--- a/platforms/src/main/kotlin/github/hua0512/plugins/huya/danmu/msg/req/HuyaUserInfo.kt
+++ b/platforms/src/main/kotlin/github/hua0512/plugins/huya/danmu/msg/req/HuyaUserInfo.kt
@@ -1,0 +1,81 @@
+/*
+ * MIT License
+ *
+ * Stream-rec  https://github.com/hua0512/stream-rec
+ *
+ * Copyright (c) 2024 hua0512 (https://github.com/hua0512)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package github.hua0512.plugins.huya.danmu.msg.req
+
+import com.qq.tars.protocol.tars.TarsInputStream
+import com.qq.tars.protocol.tars.TarsOutputStream
+import com.qq.tars.protocol.tars.TarsStructBase
+
+/**
+ * Huya websocket user info
+ *
+ * Extracted from https://hd2.huya.com/fedbasic/huyabaselibs/taf-signal/taf-signal.global.0.0.12.prod.js
+ * @author hua0512
+ * @date : 2024/2/10 18:26
+ */
+data class HuyaUserInfo(
+  var lUid: Long = 0,
+  var sGuid: String = "",
+  var sToken: String = "",
+  var sUA: String = "",
+  var sCookie: String = "",
+  var iTokenType: Int = 0,
+  var sDeviceInfo: String = "",
+  var sQIMEI: String = "",
+) : TarsStructBase() {
+
+
+  override fun readFrom(ins: TarsInputStream) {
+    ins.apply {
+      lUid = read(lUid, 0, true)
+      sGuid = read(sGuid, 1, true)
+      sToken = read(sToken, 2, true)
+      sUA = read(sUA, 3, true)
+      sCookie = read(sCookie, 4, true)
+      iTokenType = read(iTokenType, 5, true)
+      sDeviceInfo = read(sDeviceInfo, 6, true)
+      sQIMEI = read(sQIMEI, 7, true)
+    }
+  }
+
+  override fun writeTo(out: TarsOutputStream) {
+    out.apply {
+      write(lUid, 0)
+      write(sGuid, 1)
+      write(sToken, 2)
+      write(sUA, 3)
+      write(sCookie, 4)
+      write(iTokenType, 5)
+      write(sDeviceInfo, 6)
+      write(sQIMEI, 7)
+    }
+  }
+
+
+  override fun newInit(): TarsStructBase = this.copy()
+
+}

--- a/platforms/src/main/kotlin/github/hua0512/plugins/huya/danmu/msg/req/HuyaWSRegisterGroupReq.kt
+++ b/platforms/src/main/kotlin/github/hua0512/plugins/huya/danmu/msg/req/HuyaWSRegisterGroupReq.kt
@@ -1,0 +1,54 @@
+/*
+ * MIT License
+ *
+ * Stream-rec  https://github.com/hua0512/stream-rec
+ *
+ * Copyright (c) 2024 hua0512 (https://github.com/hua0512)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package github.hua0512.plugins.huya.danmu.msg.req
+
+import com.qq.tars.protocol.tars.TarsInputStream
+import com.qq.tars.protocol.tars.TarsOutputStream
+import com.qq.tars.protocol.tars.TarsStructBase
+import java.util.ArrayList
+
+/**
+ * Huya websocket register group req
+ *
+ * Extracted from https://hd2.huya.com/fedbasic/huyabaselibs/taf-signal/taf-signal.global.0.0.12.prod.js
+ * @author hua0512
+ * @date : 2024/2/10 18:28
+ */
+internal data class HuyaWSRegisterGroupReq(
+  var vGroupId: List<String?> = ArrayList(),
+  var sToken: String? = "",
+) : TarsStructBase() {
+
+  override fun writeTo(os: TarsOutputStream) {
+    os.write(this.vGroupId, 0)
+    os.write(this.sToken, 1)
+  }
+
+  override fun readFrom(`is`: TarsInputStream) {
+    this.vGroupId = `is`.readArray(this.vGroupId, 0, false)
+    this.sToken = `is`.read(this.sToken, 1, false)
+  }
+}

--- a/platforms/src/main/kotlin/github/hua0512/plugins/huya/danmu/msg/req/HuyaWup.kt
+++ b/platforms/src/main/kotlin/github/hua0512/plugins/huya/danmu/msg/req/HuyaWup.kt
@@ -1,0 +1,115 @@
+/*
+ * MIT License
+ *
+ * Stream-rec  https://github.com/hua0512/stream-rec
+ *
+ * Copyright (c) 2024 hua0512 (https://github.com/hua0512)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package github.hua0512.plugins.huya.danmu.msg.req
+
+import com.qq.tars.protocol.tars.TarsInputStream
+import com.qq.tars.protocol.tars.TarsOutputStream
+import com.qq.tars.protocol.tars.TarsStructBase
+import com.qq.tars.protocol.tars.support.TarsMethodInfo
+import com.qq.tars.protocol.util.TarsHelper
+import com.qq.tars.rpc.protocol.tars.TarsServantRequest
+import com.qq.tars.rpc.protocol.tup.UniAttribute
+import java.nio.ByteBuffer
+import java.nio.charset.StandardCharsets
+
+/**
+ * Huya wup data structure
+ * Extracted from https://hd2.huya.com/fedbasic/huyabaselibs/taf-signal/taf-signal.global.0.0.12.prod.js
+ * @author hua0512
+ * @date : 2024/8/17 21:29
+ */
+internal class HuyaWup() : TarsStructBase() {
+
+  internal val tarsServantRequest = TarsServantRequest(null).also {
+    it.methodInfo = TarsMethodInfo()
+  }
+  internal val uniAttribute = UniAttribute();
+
+
+  override fun writeTo(out: TarsOutputStream) {
+    with(out) {
+      write(TarsHelper.VERSION3, 1)
+      write(tarsServantRequest.packetType, 2)
+      write(tarsServantRequest.messageType, 3)
+      write(tarsServantRequest.requestId, 4)
+      write(tarsServantRequest.servantName, 5)
+      write(tarsServantRequest.functionName, 6)
+      write(uniAttribute.encode(), 7)
+      write(tarsServantRequest.timeout, 8)
+      write(tarsServantRequest.context, 9)
+      write(tarsServantRequest.status, 10)
+    }
+  }
+
+  override fun readFrom(ins: TarsInputStream) {
+    with(ins) {
+      tarsServantRequest.version = read(tarsServantRequest.version, 1, false)
+      tarsServantRequest.packetType = read(tarsServantRequest.packetType, 2, false)
+      tarsServantRequest.messageType = read(tarsServantRequest.messageType, 3, false)
+      tarsServantRequest.requestId = read(tarsServantRequest.requestId, 4, false)
+      tarsServantRequest.servantName = read(tarsServantRequest.servantName, 5, false)
+      tarsServantRequest.functionName = read(tarsServantRequest.functionName, 6, false)
+      uniAttribute.decode(read(byteArrayOf(), 7, false))
+      tarsServantRequest.timeout = read(tarsServantRequest.timeout, 8, false)
+      tarsServantRequest.context = readMap(tarsServantRequest.context, 9, false)
+      tarsServantRequest.status = readMap(tarsServantRequest.status, 10, false)
+    }
+  }
+
+
+  fun encode(): ByteArray {
+    val outStream = TarsOutputStream().apply {
+      setServerEncoding(StandardCharsets.UTF_8.name())
+      this@HuyaWup.writeTo(this)
+    }
+
+    val serializedData = outStream.toByteArray()
+    val length = 4 + serializedData.size
+
+    return ByteBuffer.allocate(length).apply {
+      putInt(length)
+      put(serializedData)
+    }.array()
+  }
+
+  fun decode(data: ByteArray) {
+    val buffer = ByteBuffer.wrap(data)
+    val length = try {
+      buffer.int
+    } catch (e: Exception) {
+      0
+    }
+    if (length < 4) return
+
+    val bytes = ByteArray(length - 4)
+    buffer.get(bytes)
+    this.readFrom(TarsInputStream(bytes).also {
+      it.setServerEncoding(StandardCharsets.UTF_8.name())
+    })
+  }
+
+}

--- a/platforms/src/main/kotlin/github/hua0512/plugins/huya/download/Huya.kt
+++ b/platforms/src/main/kotlin/github/hua0512/plugins/huya/download/Huya.kt
@@ -60,9 +60,7 @@ class Huya(app: App, override val danmu: HuyaDanmu, override val extractor: Huya
       onLive()
       // bind danmu properties
       with(danmu) {
-        ayyuid = extractor.ayyuid
-        topsid = extractor.topsid
-        subid = extractor.subid
+        presenterUid = extractor.presenterUid
       }
     }
   }

--- a/platforms/src/main/kotlin/github/hua0512/plugins/huya/download/HuyaExtractor.kt
+++ b/platforms/src/main/kotlin/github/hua0512/plugins/huya/download/HuyaExtractor.kt
@@ -90,7 +90,7 @@ open class HuyaExtractor(override val http: HttpClient, override val json: Json,
   internal var ayyuid: Long = 0
   internal var topsid: Long = 0
   internal var subid: Long = 0
-  internal var uid = 0L
+  internal var userId = 0L
   private var isCookieVerified = false
   var forceOrigin = false
 
@@ -243,11 +243,11 @@ open class HuyaExtractor(override val http: HttpClient, override val json: Json,
 
     withContext(Dispatchers.Default) {
       gameStreamInfoList.forEach { streamInfo ->
-        if (uid == 0L) {
+        if (userId == 0L) {
           // extract uid from cookies
           // if not found, use streamer's uid
           // if still not found, use random uid
-          uid = cookies.nonEmptyOrNull()?.let {
+          userId = cookies.nonEmptyOrNull()?.let {
             val cookie = parseClientCookiesHeader(cookies)
             cookie["yyuid"]?.toLongOrNull() ?: cookie["udb_uid"]?.toLongOrNull()
           } ?: streamInfo.jsonObject["lPresenterUid"]?.jsonPrimitive?.content?.toLongOrNull() ?: (12340000L..12349999L).random()
@@ -257,7 +257,7 @@ open class HuyaExtractor(override val http: HttpClient, override val json: Json,
         val priority = streamInfo.jsonObject["iWebPriorityRate"]?.jsonPrimitive?.int ?: 0
 
         arrayOf(true, false).forEach buildLoop@{ isFlv ->
-          val streamUrl = buildUrl(streamInfo, uid, time, null, isFlv, ctype).nonEmptyOrNull() ?: return@buildLoop
+          val streamUrl = buildUrl(streamInfo, userId, time, null, isFlv, ctype).nonEmptyOrNull() ?: return@buildLoop
           bitrateList.forEach { (bitrate, displayName) ->
             // Skip HDR streams as they are not supported
             if (displayName.contains("HDR")) return@forEach

--- a/platforms/src/main/kotlin/github/hua0512/plugins/huya/download/HuyaExtractor.kt
+++ b/platforms/src/main/kotlin/github/hua0512/plugins/huya/download/HuyaExtractor.kt
@@ -70,6 +70,7 @@ open class HuyaExtractor(override val http: HttpClient, override val json: Json,
     const val AYYUID_REGEX = "yyid\":\"?(\\d+)\"?"
     const val TOPSID_REGEX = "lChannelId\":\"?(\\d+)\"?"
     const val SUBID_REGEX = "lSubChannelId\":\"?(\\d+)\"?"
+    const val PRESENTER_UID_REGEX = "lPresenterUid\":\"?(\\d+)\"?"
 
 
     internal val requestHeaders = arrayOf(
@@ -86,10 +87,12 @@ open class HuyaExtractor(override val http: HttpClient, override val json: Json,
   private val ayyuidPattern = AYYUID_REGEX.toRegex()
   private val topsidPattern = TOPSID_REGEX.toRegex()
   private val subidPattern = SUBID_REGEX.toRegex()
+  private val presenterUidPattern = PRESENTER_UID_REGEX.toRegex()
 
-  internal var ayyuid: Long = 0
-  internal var topsid: Long = 0
-  internal var subid: Long = 0
+  //  internal var ayyuid: Long = 0
+//  internal var topsid: Long = 0
+//  internal var subid: Long = 0
+  internal var presenterUid: Long = 0
   internal var userId = 0L
   private var isCookieVerified = false
   var forceOrigin = false
@@ -135,10 +138,11 @@ open class HuyaExtractor(override val http: HttpClient, override val json: Json,
       }
     }
 
-    ayyuid = ayyuidPattern.find(htmlResponseBody)?.groupValues?.get(1)?.toLong() ?: 0
-    topsid = topsidPattern.find(htmlResponseBody)?.groupValues?.get(1)?.toLong() ?: 0
-    subid = subidPattern.find(htmlResponseBody)?.groupValues?.get(1)?.toLong() ?: 0
-
+//    ayyuid = ayyuidPattern.find(htmlResponseBody)?.groupValues?.get(1)?.toLong() ?: 0
+//    topsid = topsidPattern.find(htmlResponseBody)?.groupValues?.get(1)?.toLong() ?: 0
+//    subid = subidPattern.find(htmlResponseBody)?.groupValues?.get(1)?.toLong() ?: 0
+    presenterUid = presenterUidPattern.find(htmlResponseBody)?.groupValues?.get(1)?.toLong() ?: 0
+    
     val matchResult = ROOM_DATA_REGEX.toRegex().find(htmlResponseBody)?.also {
       if (it.value.isEmpty()) {
         throw InvalidExtractionParamsException("Empty TT_ROOM_DATA from $url")

--- a/platforms/src/main/kotlin/github/hua0512/plugins/huya/download/HuyaExtractorV2.kt
+++ b/platforms/src/main/kotlin/github/hua0512/plugins/huya/download/HuyaExtractorV2.kt
@@ -113,9 +113,10 @@ class HuyaExtractorV2(override val http: HttpClient, override val json: Json, ov
     val profileInfo = data.jsonObject["profileInfo"]?.jsonObject
 
     // get danmu properties
-    ayyuid = profileInfo?.get("yyid")?.jsonPrimitive?.long ?: 0
-    topsid = data["chTopId"]?.jsonPrimitive?.long ?: 0
-    subid = data["subChId"]?.jsonPrimitive?.long ?: 0
+//    ayyuid = profileInfo?.get("yyid")?.jsonPrimitive?.long ?: 0
+//    topsid = data["chTopId"]?.jsonPrimitive?.long ?: 0
+//    subid = data["subChId"]?.jsonPrimitive?.long ?: 0
+    presenterUid = profileInfo?.get("uid")?.jsonPrimitive?.long ?: 0
     // get avatar
     val avatarUrl = profileInfo?.get("avatar180")?.jsonPrimitive?.content ?: ""
     // get streamer name

--- a/platforms/src/test/kotlin/HuyaTest.kt
+++ b/platforms/src/test/kotlin/HuyaTest.kt
@@ -111,9 +111,7 @@ class HuyaTest {
     val danmu = HuyaDanmu(app).apply {
       enableWrite = false
       filePath = "huya_danmu.txt"
-      ayyuid = 1486578378
-      topsid = 1346609715
-      subid = 1346609715
+      presenterUid = 1346609715
     }
     val init = danmu.init(Streamer(0, "test", streamingUrl))
     danmu.fetchDanmu()


### PR DESCRIPTION
- rename `uid` variable to `userId` in `HuyaExtractor.kt`
- update all corresponding references to the renamed variable
- use reversed-engineered danmu registration workflow.